### PR TITLE
Fixed Emulicious font size

### DIFF
--- a/emulators/emulicious.dmg.ini
+++ b/emulators/emulicious.dmg.ini
@@ -10,3 +10,4 @@ WindowEmuliciousWidth=178
 GameBoyColorBootROM=cgb_boot.bin
 GameBoyBootROM=dmg_boot.bin
 System=GAME_BOY
+FontSize=11

--- a/emulators/emulicious.gbc.ini
+++ b/emulators/emulicious.gbc.ini
@@ -10,3 +10,4 @@ WindowEmuliciousWidth=178
 GameBoyColorBootROM=cgb_boot.bin
 GameBoyBootROM=dmg_boot.bin
 System=GAME_BOY_COLOR
+FontSize=11


### PR DESCRIPTION
The font size in Emulicious can be configured now. It seems like the default font size does not play well with the cropping so this PR adjusts the font size in order to fix the cropping of Emulicious's window contents.