### PR TITLE
Add web-based emulators support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 
 name: Main
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
@@ -29,10 +29,7 @@ jobs:
           python-version: '3.x'
       - name: Add python required modules
         run: |
-          python -m pip install pyautogui
-          python -m pip install pillow
-          python -m pip install requests
-          python -m pip install pywin32
+          python -m pip install -r requirements.txt
       - name: Check emulator startups
         run: |
           python main.py --get-startuptime --emulator !mGBA --emulator !KiGB --emulator !Goomba --emulator '!No$gmb' --emulator !binjgb

--- a/emulator.py
+++ b/emulator.py
@@ -41,6 +41,9 @@ class Emulator:
     def endProcess(self, p):
         p.terminate()
 
+    def undoSetup(self):
+        pass
+
     def returncode(self, p):
         return p.returncode
 

--- a/emulator.py
+++ b/emulator.py
@@ -16,7 +16,7 @@ class Emulator:
         self.title_check = lambda title: title.startswith(self.name)
         self.speed = 1.0
         self.features = features or set()
-    
+
     def setup(self):
         raise NotImplementedError()
 
@@ -29,21 +29,33 @@ class Emulator:
     def getScreenshot(self):
         return getScreenshot(self.title_check)
 
+    def isWindowOpen(self):
+        return findWindow(self.title_check) is not None
+
+    def isProcessAlive(self, p):
+        return p.poll() is None
+
+    def endProcess(self, p):
+        p.terminate()
+
+    def returncode(self, p):
+        return p.returncode
+
     def run(self, test):
         print("Running %s on %s" % (test, self))
-        
+
         sav_file = os.path.splitext(test.rom)[0] + ".sav"
         if os.path.exists(sav_file):
             os.unlink(sav_file)
-        
+
         p = self.startProcess(test.rom, model=test.model, required_features=test.required_features)
         if p is None:
             print("%s cannot run %s (incompattible model or feature requests)" % (self, test))
             return None
         process_create_time = time.monotonic()
-        while findWindow(self.title_check) is None:
+        while not self.isWindowOpen():
             time.sleep(0.01)
-            assert p.poll() is None, "Process crashed?"
+            assert self.isProcessAlive(p), "Process crashed?"
             assert time.monotonic() - process_create_time < 30.0, "Creating the window took longer then 30 seconds?"
         process_create_time = time.monotonic() - process_create_time
         self.postWindowCreation()
@@ -57,8 +69,8 @@ class Emulator:
                 if result is not None:
                     print("Early exit: %s: %g" % (result, time.monotonic() - start_time))
                     break
-            assert p.poll() is None, "Process crashed? (exit: %d)" % (p.returncode)
-        p.terminate()
+            assert self.isProcessAlive(p), "Process crashed? (exit: %d)" % (self.returncode(p))
+        self.endProcess(p)
         if result is None:
             result = test.getDefaultResult()
         return TestResult(result=result, screenshot=screenshot, startuptime=process_create_time, runtime=time.monotonic()-start_time)
@@ -67,7 +79,7 @@ class Emulator:
         p = self.startProcess(test.rom, model=test.model, required_features=test.required_features)
         if p is None:
             return None
-        while findWindow(self.title_check) is None:
+        while not self.isWindowOpen():
             time.sleep(0.01)
             assert p.poll() is None, "Process crashed?"
         time.sleep(self.startup_time)
@@ -94,20 +106,20 @@ class Emulator:
             return None, None
         reference = PIL.Image.open("startup_time_test.png")
         start_pre_window_time = time.monotonic()
-        while findWindow(self.title_check) is None:
+        while not self.isWindowOpen():
             time.sleep(0.01)
-            if p.poll() is not None or time.monotonic() - start_pre_window_time > 60.0:
+            if not self.isProcessAlive(p) or time.monotonic() - start_pre_window_time > 60.0:
                 print("Process gone or timeout")
-                if p.poll() is None:
-                    p.terminate()
+                if self.isProcessAlive(p):
+                    self.endProcess(p)
                 return None, fullscreenScreenshot()
         post_window_time = time.monotonic()
         print("Window found")
         while True:
-            if p.poll() is not None or time.monotonic() - post_window_time > 60.0:
+            if not self.isProcessAlive(p) or time.monotonic() - post_window_time > 60.0:
                 print("Process gone or timeout: %s" % (p.poll()))
-                if p.poll() is None:
-                    p.terminate()
+                if self.isProcessAlive(p):
+                    self.endProcess(p)
                 return None, fullscreenScreenshot()
             screenshot = self.getScreenshot()
             if screenshot is None:
@@ -122,7 +134,7 @@ class Emulator:
             break
         startup_time = time.monotonic() - post_window_time
         screenshot = fullscreenScreenshot()
-        p.terminate()
+        self.endProcess(p)
         return startup_time, screenshot
 
     def getJsonFilename(self):

--- a/emulator.py
+++ b/emulator.py
@@ -35,6 +35,9 @@ class Emulator:
     def isProcessAlive(self, p):
         return p.poll() is None
 
+    def processOutput(self, p):
+        return p.poll()
+
     def endProcess(self, p):
         p.terminate()
 
@@ -81,7 +84,7 @@ class Emulator:
             return None
         while not self.isWindowOpen():
             time.sleep(0.01)
-            assert p.poll() is None, "Process crashed?"
+            assert self.isProcessAlive(p), "Process crashed?"
         time.sleep(self.startup_time)
         start = time.monotonic()
         last_change = time.monotonic()
@@ -94,10 +97,10 @@ class Emulator:
             prev = screenshot
             if time.monotonic() - last_change > 10.0:
                 break
-            assert p.poll() is None, "Process crashed?"
+            assert self.isProcessAlive(p) is None, "Process crashed?"
         if not os.path.exists(test.pass_result_filename):
             screenshot.save(test.pass_result_filename)
-        p.terminate()
+        self.endProcess(p)
         return last_change - start
 
     def measureStartupTime(self, *, model):
@@ -117,7 +120,7 @@ class Emulator:
         print("Window found")
         while True:
             if not self.isProcessAlive(p) or time.monotonic() - post_window_time > 60.0:
-                print("Process gone or timeout: %s" % (p.poll()))
+                print("Process gone or timeout: %s" % (self.processOutput(p)))
                 if self.isProcessAlive(p):
                     self.endProcess(p)
                 return None, fullscreenScreenshot()

--- a/emulators/ares.py
+++ b/emulators/ares.py
@@ -14,7 +14,7 @@ class Ares(Emulator):
         self.title_check = lambda title: "ares" in title
 
     def setup(self):
-        downloadGithubRelease("ares-emulator/ares", "downloads/ares.zip", filter=lambda n: "ares" in n and "windows" in n and n.endswith(".zip"), allow_prerelease=True)
+        downloadGithubRelease("ares-emulator/ares", "downloads/ares.zip", filter=lambda n: "x64" in n and "windows" in n and n.endswith(".zip"), allow_prerelease=True)
         extract("downloads/ares.zip", "emu/ares")
 
         if not os.path.exists("emu/ares/ares.exe"):
@@ -31,12 +31,12 @@ class Ares(Emulator):
         shutil.copy(rom, target)
         return subprocess.Popen(["emu/ares/ares.exe", os.path.abspath(target)], cwd="emu/ares")
 
-    def getScreenshot(self):       
+    def getScreenshot(self):
         screenshot = getScreenshot(self.title_check)
         if screenshot is None:
             return None
         screenshot = screenshot.reduce(3)
-        if not self.cgb:        
+        if not self.cgb:
             screenshot = screenshot.convert(mode="L", dither=PIL.Image.NONE)
             screenshot = PIL.ImageOps.autocontrast(screenshot)
             screenshot.save("tmp.png")

--- a/emulators/emmy.py
+++ b/emulators/emmy.py
@@ -34,6 +34,9 @@ class Emmy(Emulator):
     def returncode(self, p):
         return 0
 
+    def undoSetup(self):
+        self.driver.quit()
+
     def startProcess(self, rom, *, model, required_features):
         systemmode = {DMG: "dmg-mode", CGB: "cgb-mode"}.get(model)
         if systemmode is None:

--- a/emulators/emmy.py
+++ b/emulators/emmy.py
@@ -1,0 +1,61 @@
+from util import *
+from emulator import Emulator
+from test import *
+from selenium import webdriver
+import PIL.Image
+
+class Emmy(Emulator):
+    def __init__(self):
+        super().__init__("Emmy", "https://emmy-gbc.vercel.app/", startup_time=0.5)
+
+    def setup(self):
+        download("https://chromedriver.storage.googleapis.com/109.0.5414.74/chromedriver_win32.zip", "downloads/chromedriver_win32.zip")
+        extract("downloads/chromedriver_win32.zip", "emu/chromedriver_win32")
+        self.driver = webdriver.Chrome("emu/chromedriver_win32/chromedriver.exe")
+        self.driver.get("http://localhost:5173/")
+        self.driver.find_element(value="emu-speed").click()
+        self.driver.find_element(value="drawer-section-settings").click()
+
+    def isWindowOpen(self):
+        return self.driver is not None
+
+    def isProcessAlive(self, p):
+        return True
+
+    def endProcess(self, p):
+        pass
+
+    def returncode(self, p):
+        return 0
+
+    def startProcess(self, rom, *, model, required_features):
+        systemmode = {DMG: "dmg-mode", CGB: "cgb-mode"}.get(model)
+        if systemmode is None:
+            return None
+        self.driver.find_element(value=systemmode).click()
+        rom_path = os.path.abspath(rom)
+        try:
+            self.driver.find_element(value="rom-input").send_keys(rom_path)
+            try:
+                # if an alert appeared, it means the rom is incompatible
+                self.driver.switch_to.alert.accept()
+                return None
+            except:
+                # no alert, so error thrown, so the rom is compatible
+                return self.driver
+        except Exception as e:
+            return None
+
+    # must return a pillow image object
+    def getScreenshot(self):
+        canvas = self.driver.find_element(value="emulator-frame")
+        canvas_base64 = self.driver.execute_script("return arguments[0].toDataURL('image/png').substring(21);", canvas)
+
+        # decode
+        canvas_png = base64.b64decode(canvas_base64)
+        # by default, 4 canvas pixels = 1 screen pixel
+        large_image = PIL.Image.open(io.BytesIO(canvas_png))
+        # resize to 1:1
+        small_image = large_image.resize((160, 144), PIL.Image.NEAREST)
+        return small_image
+

--- a/emulators/emmy.py
+++ b/emulators/emmy.py
@@ -25,6 +25,9 @@ class Emmy(Emulator):
     def isProcessAlive(self, p):
         return True
 
+    def processOutput(self, p):
+        return None
+
     def endProcess(self, p):
         pass
 

--- a/emulators/emmy.py
+++ b/emulators/emmy.py
@@ -9,10 +9,13 @@ class Emmy(Emulator):
         super().__init__("Emmy", "https://emmy-gbc.vercel.app/", startup_time=0.5)
 
     def setup(self):
+        # download("http://problemkaputt.de/no$gmb.zip", "downloads/no$gmb.zip", fake_headers=True)
+        # extract("downloads/no$gmb.zip", "emu/no$gmb")
+        # https://chromedriver.storage.googleapis.com/109.0.5414.74/chromedriver_win32.zip
         download("https://chromedriver.storage.googleapis.com/109.0.5414.74/chromedriver_win32.zip", "downloads/chromedriver_win32.zip")
         extract("downloads/chromedriver_win32.zip", "emu/chromedriver_win32")
         self.driver = webdriver.Chrome("emu/chromedriver_win32/chromedriver.exe")
-        self.driver.get("http://localhost:5173/")
+        self.driver.get("https://emmy-gbc.vercel.app/")
         self.driver.find_element(value="emu-speed").click()
         self.driver.find_element(value="drawer-section-settings").click()
 

--- a/emulators/gambatte.py
+++ b/emulators/gambatte.py
@@ -2,7 +2,6 @@ from util import *
 from emulator import Emulator
 from test import *
 import shutil
-import winreg
 
 
 class GambatteSpeedrun(Emulator):
@@ -12,6 +11,7 @@ class GambatteSpeedrun(Emulator):
         self.title_check = lambda title: "Gambatte-Speedrun" in title
 
     def setup(self):
+        import winreg
         downloadGithubRelease("pokemon-speedrunning/gambatte-speedrun", "downloads/gambatte-speedrun.zip", filter=lambda n: "theothers" in n and n.endswith(".zip"))
         extract("downloads/gambatte-speedrun.zip", "emu/gambatte-speedrun")
         download("https://gbdev.gg8.se/files/roms/bootroms/cgb_boot.bin", "emu/gambatte-speedrun/cgb_boot.bin")
@@ -29,6 +29,7 @@ class GambatteSpeedrun(Emulator):
         winreg.SetValueEx(key, "engineIndex", 0, 1, "Null")
 
     def startProcess(self, rom, *, model, required_features):
+        import winreg
         key = winreg.CreateKey(winreg.HKEY_CURRENT_USER, r"Software\gambatte\gambatte_qt")
         platform = {DMG: 0, CGB: 1, SGB: 4}.get(model)
         winreg.SetValueEx(key, "platform", 0, winreg.REG_DWORD, platform)

--- a/emulators/vba.py
+++ b/emulators/vba.py
@@ -7,7 +7,7 @@ import shutil
 class VBA(Emulator):
     def __init__(self):
         super().__init__("VisualBoyAdvance", "https://sourceforge.net/projects/", startup_time=0.6)
-    
+
     def setup(self):
         download("https://sourceforge.net/projects/vba/files/latest/download", "downloads/vba.zip")
         extract("downloads/vba.zip", "emu/vba")
@@ -25,9 +25,9 @@ class VBAM(Emulator):
     def __init__(self):
         super().__init__("VisualBoyAdvance-M", "https://vba-m.com/", startup_time=1.0)
         self.title_check = lambda title: "VisualBoyAdvance-M" in title
-    
+
     def setup(self):
-        downloadGithubRelease("visualboyadvance-m/visualboyadvance-m", "downloads/vba-m.zip", filter=lambda n: "Win" in n and "64bit" in n and n.endswith(".zip"))
+        downloadGithubRelease("visualboyadvance-m/visualboyadvance-m", "downloads/vba-m.zip", filter=lambda n: "Win" in n and "64" in n and n.endswith(".zip"))
         extract("downloads/vba-m.zip", "emu/vba-m")
         setDPIScaling("emu/vba-m/visualboyadvance-m.exe")
         download("https://gbdev.gg8.se/files/roms/bootroms/dmg_boot.bin", "emu/vba-m/dmg_boot.bin")

--- a/main.py
+++ b/main.py
@@ -94,6 +94,7 @@ if __name__ == "__main__":
                 if not checkFilter(test, args.test):
                     continue
                 print("%s: %s: %g seconds" % (emulator, test, emulator.getRunTimeFor(test)))
+            emulator.undoSetup()
         sys.exit()
     if args.dump_emulators_json:
         json.dump({
@@ -130,6 +131,7 @@ if __name__ == "__main__":
             if sgb_start_time is not None:
                 print("Startup time: %s = %g (sgb)" % (emulator, sgb_start_time))
                 f.write("%s (sgb)<br>\n<img src='data:image/png;base64,%s'>\n" % (emulator, imageToBase64(sgb_screenshot)))
+            emulator.undoSetup()
         f.write("</body></html>")
         sys.exit()
 
@@ -152,6 +154,7 @@ if __name__ == "__main__":
                     import traceback
                     print("Emulator %s failed to run properly" % (emulator))
                     traceback.print_exc()
+        emulator.undoSetup()
     emulators.sort(key=lambda emulator: len([result[0] for result in results[emulator].values() if result.result != "FAIL"]), reverse=True)
 
     for emulator in emulators:

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ from emulators.goomba import Goomba
 from emulators.binjgb import Binjgb
 from emulators.pyboy import PyBoy
 from emulators.ares import Ares
+from emulators.emmy import Emmy
 from util import *
 from test import *
 
@@ -52,6 +53,7 @@ emulators = [
     Binjgb(),
     PyBoy(),
     Ares(),
+    Emmy(),
 ]
 tests = testroms.acid.all + testroms.blarg.all + testroms.daid.all + testroms.ax6.all + testroms.mooneye.all + testroms.samesuite.all + testroms.hacktix.all + testroms.cpp.all
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ import os
 import zipfile
 import subprocess
 import time
-import win32gui
 import PIL.Image
 import PIL.ImageChops
 import sys
@@ -79,13 +78,13 @@ if __name__ == "__main__":
     parser.add_argument('--dump-emulators-json', action='store_true')
     parser.add_argument('--dump-tests-json', action='store_true')
     args = parser.parse_args()
-    
+
     tests = [test for test in tests if checkFilter(test, args.test)]
     emulators = [emulator for emulator in emulators if checkFilter(emulator, args.emulator)]
-    
+
     print("%d emulators" % (len(emulators)))
     print("%d tests" % (len(tests)))
-    
+
     if args.get_runtime:
         for emulator in emulators:
             emulator.setup()
@@ -152,7 +151,7 @@ if __name__ == "__main__":
                     print("Emulator %s failed to run properly" % (emulator))
                     traceback.print_exc()
     emulators.sort(key=lambda emulator: len([result[0] for result in results[emulator].values() if result.result != "FAIL"]), reverse=True)
-    
+
     for emulator in emulators:
         data = {
             'emulator': str(emulator),

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyautogui
 pillow
 requests
 pywin32
+selenium

--- a/util.py
+++ b/util.py
@@ -3,7 +3,6 @@ import requests
 import os
 import zipfile
 import subprocess
-import win32gui
 import PIL.Image
 import PIL.ImageChops
 import io
@@ -51,10 +50,11 @@ def extract(filename, path):
         subprocess.run([_getz7(), "x", os.path.basename(filename)[:-3]], cwd=path)
     elif filename.endswith(".7z"):
         os.makedirs(path, exist_ok=True)
-        subprocess.run([_getz7(), "x", os.path.abspath(filename)], cwd=path)        
+        subprocess.run([_getz7(), "x", os.path.abspath(filename)], cwd=path)
     return True
 
 def findWindow(title_check):
+    import win32gui
     def f(hwnd, results):
         title = win32gui.GetWindowText(hwnd)
         if title_check(title):
@@ -66,6 +66,7 @@ def findWindow(title_check):
     return None
 
 def getScreenshot(title_check):
+    import win32gui
     hwnd = findWindow(title_check)
     if not hwnd:
         print("Window not found....")


### PR DESCRIPTION
I don't know if the repo welcomes such additions, but might as well try it !

- Made the code run in non-windows environment, by moving imports of `winreg` and `win32gui` inside methods
- Added some methods to `Emulator`, allowing for more flexibility when running an emulator
- Add [Emmy](https://github.com/N1ark/gbc-emulator) emulator (I am the author of the emulator), using Selenium. Only one browser instance is opened, and ROMs are loaded for each test.

Although they're a minority, adding support for non-exe emulators could be a nice addition !