### PR TITLE
Avoid crashing when converting image to Base64

### DIFF
--- a/main.py
+++ b/main.py
@@ -196,6 +196,14 @@ if __name__ == "__main__":
     emulators.sort(key=lambda emulator: len([result[0] for result in results[emulator].values() if result.result != "FAIL"]), reverse=True)
 
     for emulator in emulators:
+        def toBase64(data):
+            if data is None:
+                return ''
+            try:
+                return imageToBase64(data)
+            except:
+                return ''
+
         data = {
             'emulator': str(emulator),
             'date': time.time(),
@@ -204,7 +212,7 @@ if __name__ == "__main__":
                     'result': result.result,
                     'startuptime': result.startuptime,
                     'runtime': result.runtime,
-                    'screenshot': imageToBase64(result.screenshot) if result.screenshot != None else '',
+                    'screenshot': toBase64(result.screenshot)
                 }
                 for test, result in results[emulator].items()
             },

--- a/main.py
+++ b/main.py
@@ -202,6 +202,8 @@ if __name__ == "__main__":
             try:
                 return imageToBase64(data)
             except:
+                print(f'Exception while converting image to base64')
+                traceback.print_exc()
                 return ''
 
         data = {


### PR DESCRIPTION
The results of my last pull request (#21) hasn't gone up because it crashed while converting a image to base64.

This change will hopefully fix that by catching any exceptions in the base64 conversion and falling backing to an empty string instead.