### PR TITLE
Fix SameBoy run & split CI into manual jobs

### DIFF
--- a/.github/workflows/ci-ares.yml
+++ b/.github/workflows/ci-ares.yml
@@ -1,0 +1,11 @@
+name: CI - ares
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: ares
+      needs_audio: true

--- a/.github/workflows/ci-bdm.yml
+++ b/.github/workflows/ci-bdm.yml
@@ -1,0 +1,11 @@
+name: CI - Beaten Dying Moon
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: Beaten Dying Moon
+      needs_audio: true

--- a/.github/workflows/ci-bgb.yml
+++ b/.github/workflows/ci-bgb.yml
@@ -1,0 +1,11 @@
+name: CI - bgb
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: bgb
+      needs_audio: true

--- a/.github/workflows/ci-binjgb.yml
+++ b/.github/workflows/ci-binjgb.yml
@@ -1,0 +1,11 @@
+name: CI - binjgb
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: binjgb
+      needs_audio: true

--- a/.github/workflows/ci-emmy.yml
+++ b/.github/workflows/ci-emmy.yml
@@ -1,0 +1,13 @@
+name: CI - Emmy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: Emmy
+      needs_chromedriver: true
+      needs_audio: false
+      extra_requirements: requirements-emmy.txt

--- a/.github/workflows/ci-emulicious.yml
+++ b/.github/workflows/ci-emulicious.yml
@@ -1,0 +1,11 @@
+name: CI - Emulicious
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: Emulicious
+      needs_audio: true

--- a/.github/workflows/ci-gambatte.yml
+++ b/.github/workflows/ci-gambatte.yml
@@ -1,0 +1,11 @@
+name: CI - GambatteSpeedrun
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: GambatteSpeedrun
+      needs_audio: true

--- a/.github/workflows/ci-gameroy.yml
+++ b/.github/workflows/ci-gameroy.yml
@@ -1,0 +1,11 @@
+name: CI - gameroy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: gameroy
+      needs_audio: true

--- a/.github/workflows/ci-goomba.yml
+++ b/.github/workflows/ci-goomba.yml
@@ -1,0 +1,11 @@
+name: CI - Goomba
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: Goomba
+      needs_audio: true

--- a/.github/workflows/ci-kigb.yml
+++ b/.github/workflows/ci-kigb.yml
@@ -1,0 +1,11 @@
+name: CI - KiGB
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: KiGB
+      needs_audio: true

--- a/.github/workflows/ci-mgba.yml
+++ b/.github/workflows/ci-mgba.yml
@@ -1,0 +1,11 @@
+name: CI - mGBA
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: mGBA
+      needs_audio: true

--- a/.github/workflows/ci-nocash.yml
+++ b/.github/workflows/ci-nocash.yml
@@ -1,0 +1,11 @@
+name: CI - No$gmb
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: No$gmb
+      needs_audio: true

--- a/.github/workflows/ci-pyboy.yml
+++ b/.github/workflows/ci-pyboy.yml
@@ -1,0 +1,11 @@
+name: CI - PyBoy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: PyBoy
+      needs_audio: true

--- a/.github/workflows/ci-sameboy.yml
+++ b/.github/workflows/ci-sameboy.yml
@@ -1,0 +1,11 @@
+name: CI - SameBoy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: SameBoy
+      needs_audio: true

--- a/.github/workflows/ci-vba.yml
+++ b/.github/workflows/ci-vba.yml
@@ -1,0 +1,11 @@
+name: CI - VisualBoyAdvance
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: VisualBoyAdvance
+      needs_audio: true

--- a/.github/workflows/ci-vbam.yml
+++ b/.github/workflows/ci-vbam.yml
@@ -1,0 +1,11 @@
+name: CI - VisualBoyAdvance-M
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: VisualBoyAdvance-M
+      needs_audio: true

--- a/.github/workflows/emulator-runner.yml
+++ b/.github/workflows/emulator-runner.yml
@@ -1,0 +1,67 @@
+name: Emulator Runner
+
+on:
+  workflow_call:
+    inputs:
+      emulator:
+        required: true
+        type: string
+      needs_chromedriver:
+        required: false
+        type: boolean
+        default: false
+      needs_audio:
+        required: false
+        type: boolean
+        default: true
+      extra_requirements:
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  run-emulator:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install base Python requirements
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-core.txt
+
+      - name: Install extra Python requirements
+        if: ${{ inputs.extra_requirements != '' }}
+        run: python -m pip install -r ${{ inputs.extra_requirements }}
+
+      - name: Install ChromeDriver
+        if: ${{ inputs.needs_chromedriver }}
+        uses: nanasess/setup-chromedriver@v2.3.0
+
+      - name: Install Scream
+        if: ${{ inputs.needs_audio }}
+        shell: powershell
+        run: |
+          Start-Service audio*
+          Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/3.6/Scream3.6.zip -OutFile C:\Scream3.6.zip
+          Extract-7Zip -Path C:\Scream3.6.zip -DestinationPath C:\Scream
+          $cert = (Get-AuthenticodeSignature C:\Scream\Install\driver\Scream.sys).SignerCertificate
+          $store = [System.Security.Cryptography.X509Certificates.X509Store]::new("TrustedPublisher", "LocalMachine")
+          $store.Open("ReadWrite")
+          $store.Add($cert)
+          $store.Close()
+          cd C:\Scream\Install\driver
+          C:\Scream\Install\helpers\devcon install Scream.inf *Scream
+
+      - name: Run emulator tests
+        run: python main.py --emulator "${{ inputs.emulator }}"
+
+      - name: Upload emulator results
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.emulator }}-results
+          path: '*.json'
+          if-no-files-found: ignore

--- a/.github/workflows/emulator-runner.yml
+++ b/.github/workflows/emulator-runner.yml
@@ -45,16 +45,46 @@ jobs:
         if: ${{ inputs.needs_audio }}
         shell: powershell
         run: |
-          Start-Service audio*
-          Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/3.6/Scream3.6.zip -OutFile C:\Scream3.6.zip
-          Extract-7Zip -Path C:\Scream3.6.zip -DestinationPath C:\Scream
-          $cert = (Get-AuthenticodeSignature C:\Scream\Install\driver\Scream.sys).SignerCertificate
+          $ErrorActionPreference = "Stop"
+
+          Start-Service -Name Audiosrv
+
+          $zipPath = "C:\Scream3.6.zip"
+          $extractPath = "C:\Scream"
+          Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/3.6/Scream3.6.zip -OutFile $zipPath
+          if (Test-Path $extractPath) {
+            Remove-Item -Path $extractPath -Recurse -Force
+          }
+          Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
+
+          $driverDir = Get-ChildItem -Path $extractPath -Recurse -Directory |
+            Where-Object { (Test-Path (Join-Path $_.FullName "Scream.sys")) -and (Test-Path (Join-Path $_.FullName "Scream.inf")) } |
+            Select-Object -First 1
+          $helpersDir = Get-ChildItem -Path $extractPath -Recurse -Directory |
+            Where-Object { Test-Path (Join-Path $_.FullName "devcon.exe") } |
+            Select-Object -First 1
+
+          if (-not $driverDir) {
+            throw "Scream driver directory was not found after extraction."
+          }
+          if (-not $helpersDir) {
+            throw "Scream helper directory containing devcon.exe was not found after extraction."
+          }
+
+          $screamSys = Join-Path $driverDir.FullName "Scream.sys"
+          $screamInf = Join-Path $driverDir.FullName "Scream.inf"
+          $devcon = Join-Path $helpersDir.FullName "devcon.exe"
+
+          $cert = (Get-AuthenticodeSignature $screamSys).SignerCertificate
+          if (-not $cert) {
+            throw "Failed to read Scream driver certificate."
+          }
           $store = [System.Security.Cryptography.X509Certificates.X509Store]::new("TrustedPublisher", "LocalMachine")
           $store.Open("ReadWrite")
           $store.Add($cert)
           $store.Close()
-          cd C:\Scream\Install\driver
-          C:\Scream\Install\helpers\devcon install Scream.inf *Scream
+
+          & $devcon install $screamInf '*Scream'
 
       - name: Run emulator tests
         run: python main.py --emulator "${{ inputs.emulator }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,84 +1,20 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Main
 
-# Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  compile:
     runs-on: windows-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
+      - name: Compile Python sources
+        run: python -m compileall -q .
 
-      # Need by Browser-based emulators.
-      - uses: nanasess/setup-chromedriver@v2
-
-      # Install virtual audio device, avoid that some emulators crash.
-      # From https://github.com/actions/runner-images/issues/2528#issuecomment-766883233
-      - name: Install Scream
-        shell: powershell
-        run: |
-          Start-Service audio*
-          Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/3.6/Scream3.6.zip -OutFile C:\Scream3.6.zip
-          Extract-7Zip -Path C:\Scream3.6.zip -DestinationPath C:\Scream
-          $cert = (Get-AuthenticodeSignature C:\Scream\Install\driver\Scream.sys).SignerCertificate
-          $store = [System.Security.Cryptography.X509Certificates.X509Store]::new("TrustedPublisher", "LocalMachine")
-          $store.Open("ReadWrite")
-          $store.Add($cert)
-          $store.Close()
-          cd C:\Scream\Install\driver
-          C:\Scream\Install\helpers\devcon install Scream.inf *Scream
-
-      - name: Add python required modules
-        run: |
-          python -m pip install -r requirements.txt
-      - name: Check emulator startups
-        run: |
-          python main.py --get-startuptime
-
-      - name: Archive startup time result
-        uses: actions/upload-artifact@v2
-        with:
-          name: startuptime
-          path: startuptime.html
-
-      - name: Run tests
-        run: |
-          python main.py
-          python main.py --dump-tests-json --dump-emulators-json
-
-      - name: Deploy pages
-        run: |
-          git config --global user.name "github actions"
-          git config --global user.email "github@actions"
-          git clone --single-branch --branch gh-pages https://github.com/daid/GBEmulatorShootout.git pages
-          cp *.json pages/
-          cd pages
-          python build.py
-          git add *.json
-          git add index.html
-          git commit -a -m 'Update'
-      - name: Push page changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-          directory: pages

--- a/emulators/sameboy.py
+++ b/emulators/sameboy.py
@@ -3,9 +3,14 @@ from emulator import Emulator
 from test import *
 import os
 import shutil
+import threading
+import time
 
 
 class SameBoy(Emulator):
+    PROMPT_TITLE = "Associate SameBoy with Game Boy ROMs"
+    PROMPT_TIMEOUT = 15.0
+
     def __init__(self):
         super().__init__("SameBoy", "https://sameboy.github.io/", startup_time=4.5, features=(PCM,))
     
@@ -33,4 +38,22 @@ class SameBoy(Emulator):
             self.startup_time = 6.5
         else:
             return None
-        return subprocess.Popen(["emu/sameboy/sameboy.exe", os.path.abspath(rom)], cwd="emu/sameboy")
+        process = subprocess.Popen(["emu/sameboy/sameboy.exe", os.path.abspath(rom)], cwd="emu/sameboy")
+        self._dismiss_association_prompt_async()
+        return process
+
+    def _dismiss_association_prompt_async(self):
+        threading.Thread(target=self._dismiss_association_prompt, daemon=True).start()
+
+    def _dismiss_association_prompt(self):
+        import win32con
+        import win32gui
+
+        deadline = time.monotonic() + self.PROMPT_TIMEOUT
+        while time.monotonic() < deadline:
+            hwnd = findWindow(lambda title: title.startswith(self.PROMPT_TITLE))
+            if hwnd:
+                win32gui.PostMessage(hwnd, win32con.WM_COMMAND, win32con.IDNO, 0)
+                win32gui.PostMessage(hwnd, win32con.WM_CLOSE, 0, 0)
+                return
+            time.sleep(0.1)

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,0 +1,5 @@
+pyautogui
+pillow
+requests
+pywin32
+tqdm

--- a/requirements-emmy.txt
+++ b/requirements-emmy.txt
@@ -1,0 +1,1 @@
+selenium


### PR DESCRIPTION
This PR accomplishes the following:

1. Fixes a problem with the latest versions of SameBoy blocking the screenshot with a file associate dialog box. We now dismiss it upon launching sameboy.
2. Main CI is now python compile only. This way we don't try to test every emulator on every commit.
3. Created a manual CI job for every emulator. This way we can selectively run the CI on a single emulator.

Tested the CI works for SameBoy on my fork.