### PR TITLE
CI: Re-Add deploy pages & Add manual "run all" CI

### DIFF
--- a/.github/workflows/ci-all.yml
+++ b/.github/workflows/ci-all.yml
@@ -8,7 +8,6 @@ permissions:
 
 jobs:
   run-all:
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -85,5 +84,6 @@ jobs:
       extra_requirements: ${{ matrix.extra_requirements }}
 
   deploy-pages:
+    if: ${{ always() }}
     needs: run-all
     uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-all.yml
+++ b/.github/workflows/ci-all.yml
@@ -1,0 +1,89 @@
+name: CI - all emulators
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  run-all:
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - emulator: Beaten Dying Moon
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: mGBA
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: KiGB
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: SameBoy
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: bgb
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: VisualBoyAdvance
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: VisualBoyAdvance-M
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: No$gmb
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: GambatteSpeedrun
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: Emulicious
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: Goomba
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: binjgb
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: PyBoy
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: ares
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+          - emulator: Emmy
+            needs_chromedriver: true
+            needs_audio: false
+            extra_requirements: requirements-emmy.txt
+          - emulator: gameroy
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: ${{ matrix.emulator }}
+      needs_chromedriver: ${{ matrix.needs_chromedriver }}
+      needs_audio: ${{ matrix.needs_audio }}
+      extra_requirements: ${{ matrix.extra_requirements }}
+
+  deploy-pages:
+    needs: run-all
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-ares.yml
+++ b/.github/workflows/ci-ares.yml
@@ -3,9 +3,16 @@ name: CI - ares
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: ares
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-bdm.yml
+++ b/.github/workflows/ci-bdm.yml
@@ -3,9 +3,16 @@ name: CI - Beaten Dying Moon
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: Beaten Dying Moon
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-bgb.yml
+++ b/.github/workflows/ci-bgb.yml
@@ -3,9 +3,16 @@ name: CI - bgb
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: bgb
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-binjgb.yml
+++ b/.github/workflows/ci-binjgb.yml
@@ -3,9 +3,16 @@ name: CI - binjgb
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: binjgb
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-emmy.yml
+++ b/.github/workflows/ci-emmy.yml
@@ -3,6 +3,9 @@ name: CI - Emmy
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
@@ -11,3 +14,7 @@ jobs:
       needs_chromedriver: true
       needs_audio: false
       extra_requirements: requirements-emmy.txt
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-emulicious.yml
+++ b/.github/workflows/ci-emulicious.yml
@@ -3,9 +3,16 @@ name: CI - Emulicious
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: Emulicious
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-gambatte.yml
+++ b/.github/workflows/ci-gambatte.yml
@@ -3,9 +3,16 @@ name: CI - GambatteSpeedrun
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: GambatteSpeedrun
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-gameroy.yml
+++ b/.github/workflows/ci-gameroy.yml
@@ -3,9 +3,16 @@ name: CI - gameroy
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: gameroy
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-goomba.yml
+++ b/.github/workflows/ci-goomba.yml
@@ -3,9 +3,16 @@ name: CI - Goomba
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: Goomba
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-kigb.yml
+++ b/.github/workflows/ci-kigb.yml
@@ -3,9 +3,16 @@ name: CI - KiGB
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: KiGB
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-mgba.yml
+++ b/.github/workflows/ci-mgba.yml
@@ -3,9 +3,16 @@ name: CI - mGBA
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: mGBA
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-nocash.yml
+++ b/.github/workflows/ci-nocash.yml
@@ -3,9 +3,16 @@ name: CI - No$gmb
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: No$gmb
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-pyboy.yml
+++ b/.github/workflows/ci-pyboy.yml
@@ -3,9 +3,16 @@ name: CI - PyBoy
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: PyBoy
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-sameboy.yml
+++ b/.github/workflows/ci-sameboy.yml
@@ -3,9 +3,16 @@ name: CI - SameBoy
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: SameBoy
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-vba.yml
+++ b/.github/workflows/ci-vba.yml
@@ -3,9 +3,16 @@ name: CI - VisualBoyAdvance
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: VisualBoyAdvance
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/ci-vbam.yml
+++ b/.github/workflows/ci-vbam.yml
@@ -3,9 +3,16 @@ name: CI - VisualBoyAdvance-M
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   run:
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: VisualBoyAdvance-M
       needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,55 @@
+name: Deploy Pages
+
+on:
+  workflow_call:
+    inputs:
+      artifact_pattern:
+        required: false
+        type: string
+        default: '*-results'
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Download emulator results
+        uses: actions/download-artifact@v5
+        with:
+          pattern: ${{ inputs.artifact_pattern }}
+          path: artifacts
+          merge-multiple: true
+
+      - name: Build and commit gh-pages update
+        shell: powershell
+        run: |
+          git config --global user.name "github actions"
+          git config --global user.email "github@actions"
+          git clone --single-branch --branch gh-pages "https://github.com/${{ github.repository }}.git" pages
+          if (Test-Path "artifacts\\*.json") {
+            Copy-Item -Path artifacts\*.json -Destination pages -Force
+          } else {
+            Write-Host "No emulator JSON artifacts found to publish."
+          }
+          Set-Location pages
+          python build.py
+          git add *.json
+          git add index.html
+          if (git diff --cached --quiet) {
+            Write-Host "No gh-pages changes to commit."
+            exit 0
+          }
+          git commit -m "Update"
+
+      - name: Push gh-pages changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          directory: pages


### PR DESCRIPTION
I accidentally forgot to keep the Deploy Pages step when we split the CI. This has been re-added.
I also added a manual CI workflow that will run *all* the emulators if you choose to do so.