### PR TITLE
Fix CI for Emmy

### DIFF
--- a/emulators/emmy.py
+++ b/emulators/emmy.py
@@ -10,7 +10,33 @@ import PIL.Image
 class Emmy(Emulator):
     def __init__(self):
         super().__init__("Emmy", "https://emmy.n1ark.com/", startup_time=0.5)
+        self.driver = None
         self.wait_timeout = 10.0
+
+    def _close_driver(self):
+        if self.driver is None:
+            return
+        try:
+            self.driver.quit()
+        finally:
+            self.driver = None
+
+    def _prepare_page(self):
+        self.driver.get(self.url)
+        self._wait(lambda driver: driver.execute_script("return document.readyState") == "complete")
+        self._wait_for_id("emu-speed", clickable=True).click()
+        self._ensure_settings_open()
+
+    def _reset_session(self, *, restart_browser=False):
+        if restart_browser or self.driver is None:
+            self._close_driver()
+            self.driver = webdriver.Chrome()
+        try:
+            self._prepare_page()
+        except Exception:
+            if restart_browser:
+                raise
+            self._reset_session(restart_browser=True)
 
     def _wait(self, condition, *, timeout=None):
         return WebDriverWait(self.driver, timeout or self.wait_timeout).until(condition)
@@ -36,11 +62,7 @@ class Emmy(Emulator):
 
     def setup(self):
         # requires: chormedriver (https://sites.google.com/chromium.org/driver/)
-        self.driver = webdriver.Chrome()
-        self.driver.get("https://emmy.n1ark.com/")
-        self._wait(lambda driver: driver.execute_script("return document.readyState") == "complete")
-        self._wait_for_id("emu-speed", clickable=True).click()
-        self._ensure_settings_open()
+        self._reset_session(restart_browser=True)
 
     def isWindowOpen(self):
         return self.driver is not None
@@ -58,12 +80,13 @@ class Emmy(Emulator):
         return 0
 
     def undoSetup(self):
-        self.driver.quit()
+        self._close_driver()
 
     def startProcess(self, rom, *, model, required_features):
         systemmode = {DMG: "dmg-mode", CGB: "cgb-mode"}.get(model)
         if systemmode is None:
             return None
+        self._reset_session()
         self._ensure_settings_open()
         self._wait_for_id(systemmode, clickable=True).click()
         rom_path = os.path.abspath(rom)

--- a/emulators/emmy.py
+++ b/emulators/emmy.py
@@ -2,18 +2,45 @@ from util import *
 from emulator import Emulator
 from test import *
 from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 import PIL.Image
 
 class Emmy(Emulator):
     def __init__(self):
         super().__init__("Emmy", "https://emmy.n1ark.com/", startup_time=0.5)
+        self.wait_timeout = 10.0
+
+    def _wait(self, condition, *, timeout=None):
+        return WebDriverWait(self.driver, timeout or self.wait_timeout).until(condition)
+
+    def _find_now(self, element_id):
+        try:
+            return self.driver.find_element(By.ID, element_id)
+        except Exception:
+            return None
+
+    def _wait_for_id(self, element_id, *, clickable=False, timeout=None):
+        condition = EC.element_to_be_clickable if clickable else EC.presence_of_element_located
+        return self._wait(condition((By.ID, element_id)), timeout=timeout)
+
+    def _ensure_settings_open(self):
+        if self._find_now("dmg-mode") is not None and self._find_now("cgb-mode") is not None:
+            return
+
+        settings_button = self._wait_for_id("drawer-section-settings", clickable=True)
+        settings_button.click()
+        self._wait_for_id("dmg-mode", timeout=self.wait_timeout)
+        self._wait_for_id("cgb-mode", timeout=self.wait_timeout)
 
     def setup(self):
         # requires: chormedriver (https://sites.google.com/chromium.org/driver/)
         self.driver = webdriver.Chrome()
         self.driver.get("https://emmy.n1ark.com/")
-        self.driver.find_element(value="emu-speed").click()
-        self.driver.find_element(value="drawer-section-settings").click()
+        self._wait(lambda driver: driver.execute_script("return document.readyState") == "complete")
+        self._wait_for_id("emu-speed", clickable=True).click()
+        self._ensure_settings_open()
 
     def isWindowOpen(self):
         return self.driver is not None
@@ -37,10 +64,11 @@ class Emmy(Emulator):
         systemmode = {DMG: "dmg-mode", CGB: "cgb-mode"}.get(model)
         if systemmode is None:
             return None
-        self.driver.find_element(value=systemmode).click()
+        self._ensure_settings_open()
+        self._wait_for_id(systemmode, clickable=True).click()
         rom_path = os.path.abspath(rom)
         try:
-            self.driver.find_element(value="rom-input").send_keys(rom_path)
+            self._wait_for_id("rom-input").send_keys(rom_path)
             try:
                 # if an alert appeared, it means the rom is incompatible
                 self.driver.switch_to.alert.accept()


### PR DESCRIPTION
This pull request refactors and improves the `Emmy` emulator integration by restructuring browser automation logic for better reliability and maintainability. The changes introduce helper methods for managing the Selenium WebDriver session, waiting for elements, and ensuring the emulator's settings are open before interaction. This makes the setup and ROM loading process more robust and less error-prone.

**Browser session management improvements:**

* Added `_close_driver` and `_reset_session` methods to handle WebDriver lifecycle, ensuring proper cleanup and reliable session restarts. (`emulators/emmy.py`)
* Updated `undoSetup` to use the new `_close_driver` method for consistent shutdown. (`emulators/emmy.py`)

**Web interaction and reliability enhancements:**

* Introduced helper methods `_wait`, `_find_now`, and `_wait_for_id` to standardize waiting for elements and interactions, reducing flakiness in browser automation. (`emulators/emmy.py`)
* Added `_ensure_settings_open` to reliably open and verify the emulator settings panel before proceeding with further actions. (`emulators/emmy.py`)
* Refactored `setup` and `startProcess` to use the new session and element-waiting logic, improving robustness when selecting system modes and uploading ROMs. (`emulators/emmy.py`) [[1]](diffhunk://#diff-862ac1e28bf261f39b0f7cb9db06acd52fb7821178f30a65ea8d34fcf0dcaae2R5-R65) [[2]](diffhunk://#diff-862ac1e28bf261f39b0f7cb9db06acd52fb7821178f30a65ea8d34fcf0dcaae2L34-R94)