### PR TITLE
Add gb-cycle emulator

### DIFF
--- a/.github/workflows/ci-all.yml
+++ b/.github/workflows/ci-all.yml
@@ -84,6 +84,10 @@ jobs:
             needs_chromedriver: false
             needs_audio: true
             extra_requirements: ''
+          - emulator: gb-cycle
+            needs_chromedriver: false
+            needs_audio: false
+            extra_requirements: ''
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: ${{ matrix.emulator }}

--- a/.github/workflows/ci-gb-cycle.yml
+++ b/.github/workflows/ci-gb-cycle.yml
@@ -1,0 +1,18 @@
+name: CI - gb-cycle
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: gb-cycle
+      needs_audio: false
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ If you'd like to contribute to the project, please read [CONTRIBUTING.md](CONTRI
 - [Emulicious](https://emulicious.net/)
 - [Gambatte-Speedrun](https://github.com/pokemon-speedrunning/gambatte-speedrun)
 - [GameRoy](https://github.com/Rodrigodd/gameroy)
+- [gb-cycle](https://github.com/pakitovic/gb-cycle)
 - [Goomba Color](https://www.dwedit.org/gba/goombacolor.php)
 - [KiGB](http://kigb.emuunlim.com/)
 - [mGBA](https://mgba.io/)

--- a/emulators/gbcycle.py
+++ b/emulators/gbcycle.py
@@ -1,0 +1,33 @@
+from util import *
+from emulator import Emulator
+from test import *
+import os
+
+
+class GbCycle(Emulator):
+    def __init__(self):
+        super().__init__("gb-cycle", "https://github.com/pakitovic/gb-cycle", startup_time=10.0, features=(PCM,))
+        self.title_check = lambda title: title.startswith("gb-desktop |")
+
+    def setup(self):
+        downloadGithubRelease(
+            "pakitovic/gb-cycle",
+            "downloads/gb-cycle.zip",
+            filter=lambda name: name == "gb-cycle-windows-x86_64.zip",
+            require_asset=True,
+        )
+        extract("downloads/gb-cycle.zip", "emu/gb-cycle")
+        self.executable = os.path.abspath("emu/gb-cycle/gb-desktop.exe")
+        setDPIScaling(self.executable)
+
+    def startProcess(self, rom, *, model, required_features):
+        if model not in (DMG, CGB, SGB):
+            return None
+
+        return subprocess.Popen([
+            self.executable,
+            os.path.abspath(rom),
+            "--model", model,
+            "--startup", "skip-boot",
+            "--test-runner",
+        ], cwd=os.path.dirname(self.executable))

--- a/main.py
+++ b/main.py
@@ -162,6 +162,12 @@ EMULATOR_SPECS = [
         'name': "GSE",
         'url': "https://github.com/CasualPokePlayer/GSE",
     },
+    {
+        'factory': lambda: _new_instance("emulators.gbcycle", "GbCycle"),
+        'keywords': ["gb-cycle", "gbcycle"],
+        'name': "gb-cycle",
+        'url': "https://github.com/pakitovic/gb-cycle",
+    },
 ]
 
 


### PR DESCRIPTION
## Summary

This PR adds **gb-cycle** to GBEmulatorShootout.

gb-cycle is another Game Boy emulator focused on accuracy and testability. Adding it here makes it easier to compare its results with the rest of the emulators already tracked by the project.

## What changed

- Added a `gb-cycle` emulator adapter.
- Registered `gb-cycle` in the emulator list.
- Added it to the README tested emulator list.
- Added a dedicated `CI - gb-cycle` workflow.
- Included it in the full CI emulator matrix.

## Why this is useful

gb-cycle is actively developed and currently passes **all** the GBEmulatorShootout test suite, so it should be a useful comparison point right away. You can take a look to my fork https://pakitovic.github.io/GBEmulatorShootout/

It also adds another open-source emulator to the shootout, with support for DMG, CGB, and SGB test runs.