### PR TITLE
Add GSE to shootout

### DIFF
--- a/.github/workflows/ci-all.yml
+++ b/.github/workflows/ci-all.yml
@@ -80,6 +80,10 @@ jobs:
             needs_chromedriver: false
             needs_audio: true
             extra_requirements: ''
+          - emulator: GSE
+            needs_chromedriver: false
+            needs_audio: true
+            extra_requirements: ''
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: ${{ matrix.emulator }}

--- a/.github/workflows/ci-gse.yml
+++ b/.github/workflows/ci-gse.yml
@@ -1,0 +1,18 @@
+name: CI - GSE
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: GSE
+      needs_audio: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/emulators/gse.py
+++ b/emulators/gse.py
@@ -10,8 +10,7 @@ class GSE(Emulator):
         self.title_check = lambda title: "GSE" in title
 
     def setup(self):
-        # downloadGithubRelease("CasualPokePlayer/GSE", "downloads/GSE.zip", filter=lambda n: "win-x64" in n and n.endswith(".zip"))
-        download("https://nightly.link/CasualPokePlayer/GSE/actions/runs/26384002488/GSE-win-x64.zip", "downloads/GSE.zip")
+        downloadGithubRelease("CasualPokePlayer/GSE", "downloads/GSE.zip", filter=lambda n: "win-x64" in n and n.endswith(".zip"))
         extract("downloads/GSE.zip", "emu/GSE")
         download("https://gbdev.gg8.se/files/roms/bootroms/cgb_boot.bin", "emu/GSE/cgb_boot.bin")
         download("https://gbdev.gg8.se/files/roms/bootroms/dmg_boot.bin", "emu/GSE/dmg_boot.bin")

--- a/emulators/gse.py
+++ b/emulators/gse.py
@@ -1,0 +1,40 @@
+from util import *
+from emulator import Emulator
+from test import *
+
+
+class GSE(Emulator):
+    def __init__(self):
+        super().__init__("GSE", "https://github.com/CasualPokePlayer/GSE", startup_time=4.5, features=(PCM,))
+
+        self.title_check = lambda title: "GSE" in title
+
+    def setup(self):
+        # downloadGithubRelease("CasualPokePlayer/GSE", "downloads/GSE.zip", filter=lambda n: "win-x64" in n and n.endswith(".zip"))
+        download("https://nightly.link/CasualPokePlayer/GSE/actions/runs/26384002488/GSE-win-x64.zip", "downloads/GSE.zip")
+        extract("downloads/GSE.zip", "emu/GSE")
+        download("https://gbdev.gg8.se/files/roms/bootroms/cgb_boot.bin", "emu/GSE/cgb_boot.bin")
+        download("https://gbdev.gg8.se/files/roms/bootroms/dmg_boot.bin", "emu/GSE/dmg_boot.bin")
+        download("https://gbdev.gg8.se/files/roms/bootroms/sgb2_boot.bin", "emu/GSE/sgb2_boot.bin")
+        setDPIScaling("emu/GSE/GSE.exe")
+
+        open("emu/GSE/portable.txt", "w").close()
+
+    def startProcess(self, rom, *, model, required_features):
+        gb_platform = {DMG: "GB", CGB: "GBC", SGB: "SGB2"}.get(model)
+        self.startup_time = 6.0 if model == DMG else 4.0
+        return subprocess.Popen([
+            "emu/GSE/GSE.exe",
+            os.path.abspath(rom),
+            "--gb-bios", os.path.abspath("emu/GSE/dmg_boot.bin"),
+            "--gbc-bios", os.path.abspath("emu/GSE/cgb_boot.bin"),
+            "--sgb2-bios", os.path.abspath("emu/GSE/sgb2_boot.bin"),
+            "--gb-platform", gb_platform,
+            "--apply-color-correction", "false",
+            "--hide-sgb-border", "true",
+            "--hide-status-bar", "true",
+            "--hide-menu-bar-on-unpause", "true",
+            "--software-renderer",
+            "--window-scale", "1",
+            "--disable-win11-round-corners", "true"
+        ], cwd="emu/GSE")

--- a/main.py
+++ b/main.py
@@ -156,6 +156,12 @@ EMULATOR_SPECS = [
         'name': "docboy",
         'url': "https://github.com/Docheinstein/docboy",
     },
+    {
+        'factory': lambda: _new_instance("emulators.gse", "GSE"),
+        'keywords': ["Game Boy Speedrun Emulator", "GSE", "gse"],
+        'name': "GSE",
+        'url': "https://github.com/CasualPokePlayer/GSE",
+    },
 ]
 
 


### PR DESCRIPTION
Currently, this is set to just download the currently latest CI build (which contains a CLI)

Resolves #44 

Keeping as draft until GSE v0.6 releases.