### PR TITLE
Add WATaBoy emulator

### DIFF
--- a/.github/workflows/ci-all.yml
+++ b/.github/workflows/ci-all.yml
@@ -84,6 +84,10 @@ jobs:
             needs_chromedriver: false
             needs_audio: true
             extra_requirements: ''
+          - emulator: WATaBoy
+            needs_chromedriver: false
+            needs_audio: false
+            extra_requirements: ''
     uses: ./.github/workflows/emulator-runner.yml
     with:
       emulator: ${{ matrix.emulator }}

--- a/.github/workflows/ci-wataboy.yml
+++ b/.github/workflows/ci-wataboy.yml
@@ -1,0 +1,18 @@
+name: CI - WATaBoy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: WATaBoy
+      needs_audio: false
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/emulators/wataboy.py
+++ b/emulators/wataboy.py
@@ -7,6 +7,7 @@ import shutil
 class WATaBoy(Emulator):
     def __init__(self):
         super().__init__("wataboy", "https://humphri.es/WATaBoy/", startup_time=0.6)
+        self.speed = 10.0
     
     def setup(self):
         downloadGithubRelease("energeticbark/WATaBoy", "downloads/wataboy.zip")

--- a/emulators/wataboy.py
+++ b/emulators/wataboy.py
@@ -1,0 +1,21 @@
+from util import *
+from emulator import Emulator
+from test import *
+import shutil
+
+
+class WATaBoy(Emulator):
+    def __init__(self):
+        super().__init__("wataboy", "https://humphri.es/WATaBoy/", startup_time=0.6)
+    
+    def setup(self):
+        downloadGithubRelease("energeticbark/WATaBoy", "downloads/wataboy.zip")
+        extract("downloads/wataboy.zip", "emu/wataboy")
+        setDPIScaling("emu/wataboy/native-interp.exe")
+    
+    def startProcess(self, rom, *, model, required_features):
+        if model != DMG:
+            return None
+
+        return subprocess.Popen(["emu/wataboy/native-interp.exe", os.path.abspath(rom)], cwd="emu/wataboy")
+

--- a/main.py
+++ b/main.py
@@ -162,6 +162,12 @@ EMULATOR_SPECS = [
         'name': "GSE",
         'url': "https://github.com/CasualPokePlayer/GSE",
     },
+    {
+        'factory': lambda: _new_instance("emulators.wataboy", "WATaBoy"),
+        'keywords': ["WATaBoy", "wataboy"],
+        'name': "WATaBoy",
+        'url': "https://github.com/EnergeticBark/WATaBoy",
+    },
 ]
 
 


### PR DESCRIPTION
This PR adds support for [WATaBoy](https://github.com/EnergeticBark/WATaBoy), a performance-focused Game Boy emulator with the goal of cycle-accuracy alongside JIT compilation. It's architecturally similar to [GameRoy](https://github.com/Rodrigodd/gameroy) (already part of the shootout), but with a dynamic recompiler that targets Wasm rather than x86.

APU and CGB/SGB functionality are currently unimplemented.

Local testing shows it passing 102/163 supported tests.
<img width="171" height="78" alt="Screenshot 2026-07-14 144925" src="https://github.com/user-attachments/assets/fbe4a78e-e1d7-4ce1-801b-c3448238ac2b" />
