### PR TITLE
Add Coffee GB emulator support

### DIFF
--- a/.github/workflows/ci-all.yml
+++ b/.github/workflows/ci-all.yml
@@ -60,6 +60,11 @@ jobs:
             needs_chromedriver: false
             needs_audio: true
             extra_requirements: ''
+          - emulator: Coffee GB
+            needs_chromedriver: false
+            needs_audio: true
+            needs_java: true
+            extra_requirements: ''
           - emulator: PyBoy
             needs_chromedriver: false
             needs_audio: true
@@ -89,6 +94,7 @@ jobs:
       emulator: ${{ matrix.emulator }}
       needs_chromedriver: ${{ matrix.needs_chromedriver }}
       needs_audio: ${{ matrix.needs_audio }}
+      needs_java: ${{ matrix.needs_java || false }}
       extra_requirements: ${{ matrix.extra_requirements }}
 
   deploy-pages:

--- a/.github/workflows/ci-coffeegb.yml
+++ b/.github/workflows/ci-coffeegb.yml
@@ -1,0 +1,19 @@
+name: CI - Coffee GB
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  run:
+    uses: ./.github/workflows/emulator-runner.yml
+    with:
+      emulator: Coffee GB
+      needs_audio: true
+      needs_java: true
+
+  deploy-pages:
+    needs: run
+    uses: ./.github/workflows/deploy-pages.yml

--- a/.github/workflows/emulator-runner.yml
+++ b/.github/workflows/emulator-runner.yml
@@ -14,6 +14,10 @@ on:
         required: false
         type: boolean
         default: true
+      needs_java:
+        required: false
+        type: boolean
+        default: false
       extra_requirements:
         required: false
         type: string
@@ -27,6 +31,13 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
+
+      - name: Install Java
+        if: ${{ inputs.needs_java }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
 
       - name: Install base Python requirements
         run: |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ If you'd like to contribute to the project, please read [CONTRIBUTING.md](CONTRI
 - [Beaten Dying Moon](https://mattcurrie.com/bdm-demo/)
 - [BGB](https://bgb.bircd.org/)
 - [binjgb](https://github.com/binji/binjgb)
+- [Coffee GB](https://github.com/trekawek/coffee-gb)
 - [DocBoy](https://github.com/Docheinstein/docboy)
 - [Emmy](https://emmy.n1ark.com/)
 - [Emulicious](https://emulicious.net/)
@@ -42,6 +43,7 @@ If you'd like to contribute to the project, please read [CONTRIBUTING.md](CONTRI
 
 - Windows (for running most emulators)
 - Python 3.7+
+- Java 16+ (for Coffee GB)
 
 ## Usage
 

--- a/emulators/coffeegb.py
+++ b/emulators/coffeegb.py
@@ -48,6 +48,7 @@ class CoffeeGB(Emulator):
                     "display.rotation=0",
                     "display.showSgbBorder=false",
                     "sound.enabled=false",
+                    "system.bootstrapMode=FAST_FORWARD",
                 ])
             )
 

--- a/emulators/coffeegb.py
+++ b/emulators/coffeegb.py
@@ -1,0 +1,60 @@
+import os
+
+from emulator import Emulator
+from test import *
+from util import *
+
+
+class CoffeeGB(Emulator):
+    def __init__(self):
+        super().__init__(
+            "Coffee GB",
+            "https://github.com/trekawek/coffee-gb",
+            startup_time=2.0,
+            features=(PCM,),
+        )
+
+    def setup(self):
+        downloadGithubRelease(
+            "trekawek/coffee-gb",
+            "downloads/coffee-gb.jar",
+            filter=lambda name: name.startswith("coffee-gb-") and name.endswith(".jar"),
+            require_asset=True,
+        )
+
+    def startProcess(self, rom, *, model, required_features):
+        model = {DMG: "DMG", CGB: "CGB", SGB: "SGB"}.get(model)
+        if model is None:
+            return None
+
+        home = os.path.abspath(os.path.join("emu", "coffee-gb", model.lower()))
+        os.makedirs(home, exist_ok=True)
+        with open(os.path.join(home, ".coffeegb.properties"), "wt") as f:
+            f.write(
+                "\n".join([
+                    "system.dmgGames=%s" % model,
+                    "system.cgbGames=%s" % model,
+                    "display.scale=1",
+                    "display.grayscale=false",
+                    "display.blending=false",
+                    "display.colorCorrection=false",
+                    "display.rotation=0",
+                    "display.showSgbBorder=false",
+                    "sound.enabled=false",
+                ])
+            )
+
+        return subprocess.Popen([
+            "java",
+            "-Dsun.java2d.uiScale=1",
+            "-Duser.home=%s" % home,
+            "-jar",
+            os.path.abspath("downloads/coffee-gb.jar"),
+            os.path.abspath(rom),
+        ], cwd=home)
+
+    def getScreenshot(self):
+        screenshot = getScreenshot(self.title_check)
+        if screenshot is None or screenshot.size[0] < 160 or screenshot.size[1] < 144:
+            return None
+        return screenshot.crop((0, screenshot.size[1] - 144, 160, screenshot.size[1]))

--- a/emulators/coffeegb.py
+++ b/emulators/coffeegb.py
@@ -5,22 +5,29 @@ from test import *
 from util import *
 
 
+COFFEE_GB_VERSION = "1.7.8"
+COFFEE_GB_JAR = os.path.join("downloads", "coffee-gb-%s.jar" % COFFEE_GB_VERSION)
+COFFEE_GB_URL = (
+    "https://github.com/trekawek/coffee-gb/releases/download/"
+    "coffee-gb-%s/coffee-gb-%s.jar" % (COFFEE_GB_VERSION, COFFEE_GB_VERSION)
+)
+
+
 class CoffeeGB(Emulator):
     def __init__(self):
         super().__init__(
             "Coffee GB",
             "https://github.com/trekawek/coffee-gb",
-            startup_time=2.0,
+            startup_time=15.0,
             features=(PCM,),
         )
+        # Coffee GB starts a fresh JVM and Swing UI for every ROM. On slower Windows
+        # hosts it may run well below real time while the JVM is still warming up.
+        # This only extends the deadline; matching screenshots still exit early.
+        self.speed = 0.2
 
     def setup(self):
-        downloadGithubRelease(
-            "trekawek/coffee-gb",
-            "downloads/coffee-gb.jar",
-            filter=lambda name: name.startswith("coffee-gb-") and name.endswith(".jar"),
-            require_asset=True,
-        )
+        download(COFFEE_GB_URL, COFFEE_GB_JAR)
 
     def startProcess(self, rom, *, model, required_features):
         model = {DMG: "DMG", CGB: "CGB", SGB: "SGB"}.get(model)
@@ -49,7 +56,7 @@ class CoffeeGB(Emulator):
             "-Dsun.java2d.uiScale=1",
             "-Duser.home=%s" % home,
             "-jar",
-            os.path.abspath("downloads/coffee-gb.jar"),
+            os.path.abspath(COFFEE_GB_JAR),
             os.path.abspath(rom),
         ], cwd=home)
 

--- a/emulators/coffeegb.py
+++ b/emulators/coffeegb.py
@@ -5,12 +5,7 @@ from test import *
 from util import *
 
 
-COFFEE_GB_VERSION = "1.7.8"
-COFFEE_GB_JAR = os.path.join("downloads", "coffee-gb-%s.jar" % COFFEE_GB_VERSION)
-COFFEE_GB_URL = (
-    "https://github.com/trekawek/coffee-gb/releases/download/"
-    "coffee-gb-%s/coffee-gb-%s.jar" % (COFFEE_GB_VERSION, COFFEE_GB_VERSION)
-)
+COFFEE_GB_JAR = os.path.join("downloads", "coffee-gb.jar")
 
 
 class CoffeeGB(Emulator):
@@ -27,7 +22,12 @@ class CoffeeGB(Emulator):
         self.speed = 0.2
 
     def setup(self):
-        download(COFFEE_GB_URL, COFFEE_GB_JAR)
+        downloadGithubRelease(
+            "trekawek/coffee-gb",
+            COFFEE_GB_JAR,
+            filter=lambda name: name.startswith("coffee-gb-") and name.endswith(".jar"),
+            require_asset=True,
+        )
 
     def startProcess(self, rom, *, model, required_features):
         model = {DMG: "DMG", CGB: "CGB", SGB: "SGB"}.get(model)

--- a/main.py
+++ b/main.py
@@ -127,6 +127,12 @@ EMULATOR_SPECS = [
         'url': "https://github.com/binji/binjgb",
     },
     {
+        'factory': lambda: _new_instance("emulators.coffeegb", "CoffeeGB"),
+        'keywords': ["Coffee GB", "coffee-gb", "coffeegb"],
+        'name': "Coffee GB",
+        'url': "https://github.com/trekawek/coffee-gb",
+    },
+    {
         'factory': lambda: _new_instance("emulators.pyboy", "PyBoy"),
         'keywords': ["PyBoy", "pyboy"],
         'name': "PyBoy",


### PR DESCRIPTION
## Summary

- add an adapter that downloads the latest Coffee GB release JAR
- configure isolated DMG, CGB, and SGB profiles with a deterministic 1x display
- crop Swing UI chrome from screenshots and advertise PCM support
- register Coffee GB aliases and document its Java requirement
- include Coffee GB in the github workflow

## Validation

- tested on a Windows machine
- tested the workflow automation in a local fork:
    - https://github.com/trekawek/GBEmulatorShootout/actions/runs/29872728334/job/88783794695
    - https://tomek.rekawek.eu/GBEmulatorShootout/
- it passes all 264 tests